### PR TITLE
Overcome dynamic target limitations

### DIFF
--- a/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/sink/MqttWriter.scala
+++ b/kafka-connect-mqtt/src/main/scala/io/lenses/streamreactor/connect/mqtt/sink/MqttWriter.scala
@@ -80,16 +80,19 @@ class MqttWriter(client: MqttClient, settings: MqttSinkSettings, convertersMap: 
                       k.hasRetainStructure,
                     )
 
-                    //get kafka message key if asked for
+                    mqttTarget = k.getTarget
+
+                    // If there is a _key placeholder, replace it with the message key
+                    if (mqttTarget.contains("_key")) {
+                      mqttTarget = mqttTarget.replace("_key", r.key().toString)
+                    }
+
+                    // If there is a dynamic target, extract the value and replace the placeholders
                     if (Option(k.getDynamicTarget).getOrElse("").nonEmpty) {
-                      val mqtttopic = (parse(transformed.toString) \ k.getDynamicTarget).extractOrElse[String](null)
-                      if (mqtttopic.nonEmpty) {
-                        mqttTarget = mqtttopic
+                      val extracted = (parse(transformed.toString) \ k.getDynamicTarget).extractOrElse[String](null)
+                      if (extracted.nonEmpty) {
+                        mqttTarget = mqttTarget.replace("$" + k.getDynamicTarget, extracted)
                       }
-                    } else if (k.getTarget == "_key") {
-                      mqttTarget = r.key().toString
-                    } else {
-                      mqttTarget = k.getTarget
                     }
 
                     val converter = convertersMap.getOrElse(k.getSource, null)


### PR DESCRIPTION
fix: Overcome dynamic target limitations

Current implementation has some limitation with regards to the target topic when using dynamic fields

1. You cannot combine a dynamic target with static text e.g. `/something/$field/else` will publish to `/$field`
2. You cannot combine _key and dynamic target for the destination topic e.g. `/something/_key/else/$field` will publish to `/_key`
3. You cannot combine _key with some static text e.g. `/something/_key` will publish to `/_key`

Proposed solution overcomes all above issues

Fixes #1642